### PR TITLE
Update finetune.py

### DIFF
--- a/finetune/finetune.py
+++ b/finetune/finetune.py
@@ -48,8 +48,8 @@ class SupervisedDataset(Dataset):
         data_path,
         tokenizer,
         model_max_length=4096,
-        user_tokens=[1786, 4194, 95388],
-        assistant_tokens=[1786, 10850, 95388],
+        user_tokens=[1786, 4194],
+        assistant_tokens=[1786, 10850],
     ):
         super(SupervisedDataset, self).__init__()
         self.data = json.load(open(data_path))


### PR DESCRIPTION
```python
    def __init__(
        self,
        data_path,
        tokenizer,
        model_max_length=4096,
        user_tokens=[1786, 4194, 95388],
        assistant_tokens=[1786, 10850, 95388],
    ): 
```
We try to do sft on `MiniCPM-1B-sft-bp16`, but there is an error, because the token "95388", which means '' (empty string). However there is no token(95388) inside the model embedding. So we delete the 95388. the code we modified:
```python
        user_tokens=[1786, 4194],
        assistant_tokens=[1786, 10850],
```
<img width="653" alt="image" src="https://github.com/OpenBMB/MiniCPM/assets/79465126/25311368-df3f-4ab8-80a0-cf457b44665e">
