### PR TITLE
docs: fix MiniCPM Desk Pet install guidance

### DIFF
--- a/README-cn.md
+++ b/README-cn.md
@@ -420,10 +420,10 @@ vllm serve ${model_path} \
 
 <a href="https://youtu.be/Ee0slMW8SEk"><img src="https://img.youtube.com/vi/Ee0slMW8SEk/0.jpg" alt="MiniCPM Desk Pet video demo" width="720"></a>
 
-桌宠支持 Apple Silicon / NVIDIA GPU / CPU 路线，可以与 Cursor、Claude Code、Codex 等编码 agent 联动，并支持 LoRA 人格切换。
+桌宠支持 macOS Apple Silicon 和带 Vulkan 支持的 Windows x64，可以与 Cursor、Claude Code、Codex 等编码 agent 联动，并支持基于 LoRA 适配器的人格切换。
 
-- **用户安装**：从 [Releases](https://github.com/OpenBMB/MiniCPM-Desk-Pet/releases) 下载 `Clawd-on-Desk-*-arm64.dmg`，按引导完成环境检查、模型下载和 sidecar 启动。
-- **开发者运行**：`git clone git@github.com:OpenBMB/MiniCPM-Desk-Pet.git && ./go.sh`，详见 [`MiniCPM-Desk-Pet/README.md`](https://github.com/OpenBMB/MiniCPM-Desk-Pet#给开发者)。
+- **用户安装**：从 [Releases](https://github.com/OpenBMB/MiniCPM-Desk-Pet/releases) 下载最新 macOS `MiniCPM Desk Pet-*-arm64.dmg` 或 Windows `.exe` 安装程序，按引导完成环境检查、模型下载和模型预热。
+- **开发者运行**：`git clone git@github.com:OpenBMB/MiniCPM-Desk-Pet.git && cd MiniCPM-Desk-Pet && ./go.sh`，完整设置流程见 [`docs/development.md`](https://github.com/OpenBMB/MiniCPM-Desk-Pet/blob/main/docs/development.md)。
 
 > 桌宠 UI 层 fork 自 [@rullerzhou-afk/clawd-on-desk](https://github.com/rullerzhou-afk/clawd-on-desk)（AGPL-3.0）。我们在上游桌宠运行时、动画包和多 agent 集成基础上，加入本地 MiniCPM5-1B sidecar、Onboarding 和 LoRA 人格切换。完整致谢见 [`NOTICE.md`](https://github.com/OpenBMB/MiniCPM-Desk-Pet/blob/main/NOTICE.md)。
 

--- a/README.md
+++ b/README.md
@@ -430,10 +430,10 @@ We also ship **[OpenBMB/MiniCPM-Desk-Pet](https://github.com/OpenBMB/MiniCPM-Des
 
 <a href="https://youtu.be/Ee0slMW8SEk"><img src="https://img.youtube.com/vi/Ee0slMW8SEk/0.jpg" alt="MiniCPM Desk Pet video demo" width="720"></a>
 
-The pet supports Apple Silicon / NVIDIA GPU / CPU paths, can work with coding agents such as Cursor, Claude Code, and Codex, and supports LoRA persona switching.
+The pet supports macOS Apple Silicon and Windows x64 with Vulkan support, can work with coding agents such as Cursor, Claude Code, and Codex, and supports persona adapter switching backed by LoRA adapters.
 
-- **User install**: grab `Clawd-on-Desk-*-arm64.dmg` from [Releases](https://github.com/OpenBMB/MiniCPM-Desk-Pet/releases), then follow the onboarding flow for environment checks, model download, and sidecar startup.
-- **Developer run**: `git clone git@github.com:OpenBMB/MiniCPM-Desk-Pet.git && ./go.sh` — see [`MiniCPM-Desk-Pet/README.md`](https://github.com/OpenBMB/MiniCPM-Desk-Pet#给开发者) for the full setup.
+- **User install**: download the latest macOS `MiniCPM Desk Pet-*-arm64.dmg` or Windows `.exe` installer from [Releases](https://github.com/OpenBMB/MiniCPM-Desk-Pet/releases), then follow the onboarding flow for environment checks, model download, and model warm-up.
+- **Developer run**: `git clone git@github.com:OpenBMB/MiniCPM-Desk-Pet.git && cd MiniCPM-Desk-Pet && ./go.sh` — see [`docs/development.md`](https://github.com/OpenBMB/MiniCPM-Desk-Pet/blob/main/docs/development.md) for the full setup.
 
 > The pet UI layer is forked from [@rullerzhou-afk/clawd-on-desk](https://github.com/rullerzhou-afk/clawd-on-desk) (AGPL-3.0). On top of the upstream pet runtime, animation packs, and multi-agent integrations, we add the local MiniCPM5-1B sidecar, onboarding flow, and LoRA persona switching. Full attribution in [`NOTICE.md`](https://github.com/OpenBMB/MiniCPM-Desk-Pet/blob/main/NOTICE.md).
 


### PR DESCRIPTION
## Summary

This PR tightens the `Desktop Pet` / `桌宠` sections in the main MiniCPM README files so they match the current MiniCPM Desk Pet documentation and avoid sending users to stale Clawd-on-Desk-era instructions.

Changes made:

- Replace the stale `Clawd-on-Desk-*-arm64.dmg` installer name with the MiniCPM Desk Pet installer name documented by the Desk Pet repository: `MiniCPM Desk Pet-*-arm64.dmg`.
- Mention the Windows `.exe` installer path alongside the macOS DMG path, matching the Desk Pet README's platform-specific installation instructions.
- Apply the same install guidance fix to both `README.md` and `README-cn.md`.
- Update the platform wording from the broader and slightly misleading `Apple Silicon / NVIDIA GPU / CPU paths` phrase to the user-facing release targets documented in MiniCPM Desk Pet: macOS Apple Silicon and Windows x64 with Vulkan support.
- Align the persona wording with the Desk Pet README's `Persona Adapters` language while preserving the implementation detail that these adapters are backed by LoRA adapters.
- Fix the developer command by adding `cd MiniCPM-Desk-Pet`; the previous `git clone ... && ./go.sh` command would run `./go.sh` from the parent directory and fail.
- Replace the stale `#给开发者` README anchor with the current `docs/development.md` developer setup page.
- Align the onboarding wording with the Desk Pet README's first-launch flow by using `environment checks, model download, and model warm-up` / `环境检查、模型下载和模型预热` instead of the lower-level `sidecar startup` phrasing.

## Reference Checked

I used the current `OpenBMB/MiniCPM-Desk-Pet` documentation as the source of truth for this cleanup:

- `OpenBMB/MiniCPM-Desk-Pet` README, `Installation` section:
  - macOS users are instructed to download `MiniCPM Desk Pet-*-arm64.dmg` from Releases.
  - Windows users are instructed to download the latest `.exe` installer.
- `OpenBMB/MiniCPM-Desk-Pet` README / `README.zh-CN.md`, `System Requirements` section:
  - macOS: 14.0+, Apple Silicon.
  - Windows: x64 with Vulkan support.
- `OpenBMB/MiniCPM-Desk-Pet` README / `README.zh-CN.md`, `First Launch` section:
  - The setup flow is documented as `Environment Check -> Model Download -> Model Warm-up -> Ready to Use`.
- `OpenBMB/MiniCPM-Desk-Pet` README / `README.zh-CN.md`, developer notes section:
  - Development setup is now routed to `docs/development.md`.
- `OpenBMB/MiniCPM-Desk-Pet` release metadata:
  - The latest release publishes macOS and Windows installer assets, so the main MiniCPM README files should not describe only a macOS DMG path.

Reference repository: https://github.com/OpenBMB/MiniCPM-Desk-Pet

## Why This Matters

The previous MiniCPM README text mixed current MiniCPM Desk Pet guidance with stale upstream Clawd-on-Desk naming. That can confuse users in two ways:

1. The documented DMG name points users toward a non-MiniCPM artifact pattern.
2. Windows users are not told that the Desk Pet repository provides a Windows installer, even though the referenced project README documents one.

The developer-run command also needed a small but practical fix. Without changing into the cloned repository first, the command cannot find `./go.sh`.

The same stale content existed in the Chinese README, so this PR keeps the English and Chinese Desktop Pet sections aligned.

## Validation

- Confirmed the target README sections before and after the edit.
- Confirmed the stale strings are no longer present in `README.md` or `README-cn.md`:
  - `Clawd-on-Desk-*-arm64.dmg`
  - `#给开发者`
  - `git clone ... && ./go.sh` without `cd MiniCPM-Desk-Pet`
  - `Apple Silicon / NVIDIA GPU / CPU`
  - `sidecar 启动`
- Checked the replacement links return HTTP 200:
  - `https://github.com/OpenBMB/MiniCPM-Desk-Pet/releases`
  - `https://github.com/OpenBMB/MiniCPM-Desk-Pet/blob/main/docs/development.md`
  - `https://raw.githubusercontent.com/OpenBMB/MiniCPM-Desk-Pet/main/README.md`
- Ran `git diff --check` for the documentation diff.

No code paths or model behavior are changed by this PR.
