### PR TITLE
docs(deployment): fix unsupported / inaccurate workarounds in MiniCPM…

### DIFF
--- a/docs/deployment/arclight.md
+++ b/docs/deployment/arclight.md
@@ -22,7 +22,14 @@ cmake --build build --config Release -j 32
 
 ## Preparing a Model
 
-ArcLight uses the GGUF model format from [llama.cpp](https://github.com/ggml-org/llama.cpp). Download a GGUF checkpoint from Hugging Face or convert your own model by following the llama.cpp GGUF conversion workflow.
+ArcLight uses the GGUF model format from [llama.cpp](https://github.com/ggml-org/llama.cpp). The current `nnml` backend only ships kernels for **`f32` / `f16` / `q4_0` / `q8_0` / `q6_K` / `q8_K`** (see `nnml/src/ops/types.cpp`); other quants such as `Q4_K_M` will not load.
+
+The official `openbmb/MiniCPM5-1B-GGUF` repo publishes `F16`, `Q8_0`, and `Q4_K_M` — note that **`Q4_0` is not included**. For a `q4_0` build you have to quantize it yourself from the released `F16`:
+
+```bash
+huggingface-cli download openbmb/MiniCPM5-1B-GGUF MiniCPM5-1B-F16.gguf --local-dir .
+llama-quantize ./MiniCPM5-1B-F16.gguf ./MiniCPM5-1B-Q4_0.gguf Q4_0
+```
 
 The current codebase includes model definitions for:
 
@@ -30,7 +37,7 @@ The current codebase includes model definitions for:
 - Qwen3
 - Llama2
 
-For first-time testing, start with MiniCPM5-1B or another small GGUF model, preferably a quantized checkpoint such as `Q4_0`.
+For first-time testing, start with MiniCPM5-1B or another small GGUF model, preferably the locally produced `Q4_0` (smallest) or the released `Q8_0`.
 
 ## Building
 

--- a/docs/deployment/lmstudio.md
+++ b/docs/deployment/lmstudio.md
@@ -127,7 +127,7 @@ When LM Studio's `mlx-llm` runtime detects a `<think>...</think>` block in the m
 
 The GGUF runtime does not do this split — `<think>...</think>` is emitted inline as part of `content`, and you have to strip it client-side. If your downstream client supports the OpenAI reasoning extension (Cursor, Continue, etc.), prefer the MLX runtime.
 
-> 💡 Always pass an explicit `stop` array including both `<|im_end|>` and `<|im_start|>`. LM Studio's bundled chat template emits the assistant turn correctly, but its OpenAI-compat layer does not auto-attach the `<|im_end|>` stop string, so without it the model will sometimes continue past the EOT marker into a second hallucinated turn.
+> 💡 If you observe the model continuing past `<|im_end|>` into a hallucinated second turn, add `"stop": ["<|im_end|>", "<|im_start|>"]` to the request. `<|im_end|>` is token id 130073 and is already in the GGUF's `eos_token_id` array, so LM Studio normally stops there on its own — only resort to an explicit `stop` array if you actually see overrun in practice.
 
 ## Recommended sampling
 
@@ -144,12 +144,29 @@ The cleanest workaround is to **register two extra model variants with the `enab
 
 ### One-time setup script
 
+The script below operates on already-imported MLX folders under `~/.lmstudio/models/openbmb/`. **Get them there first** — there is no pre-converted `MiniCPM5-1B-MLX-Q4` / `MiniCPM5-1B-MLX-bf16` Hugging Face repo to clone; the only published MLX repo is [`openbmb/MiniCPM5-1B-MLX`](https://huggingface.co/openbmb/MiniCPM5-1B-MLX) (4-bit affine). Either drop it in as-is, or build the two flavours locally with `mlx_lm.convert` (see [`mlx.md`](./mlx.md)) and `mv` them into the LM Studio registry, e.g.:
+
+```bash
+# Option A — use the official 4-bit affine repo as a single source
+mkdir -p ~/.lmstudio/models/openbmb/MiniCPM5-1B-MLX
+huggingface-cli download openbmb/MiniCPM5-1B-MLX \
+    --local-dir ~/.lmstudio/models/openbmb/MiniCPM5-1B-MLX
+
+# Option B — build both flavours from the fp16 HF repo
+HF=openbmb/MiniCPM5-1B
+mlx_lm.convert --hf-path "$HF" --mlx-path ~/.lmstudio/models/openbmb/MiniCPM5-1B-MLX-bf16
+mlx_lm.convert --hf-path "$HF" --mlx-path ~/.lmstudio/models/openbmb/MiniCPM5-1B-MLX-Q4 -q --q-bits 4
+```
+
+Then list the flavours you want the variant script to touch in `SOURCES`.
+
 ```bash
 python3 - <<'PY'
 import os, re, shutil
 
 ROOT = os.path.expanduser("~/.lmstudio/models/openbmb")
-SOURCES = ["MiniCPM5-1B-MLX-Q4", "MiniCPM5-1B-MLX-bf16"]
+# Set to whichever flavour folders actually exist under ROOT:
+SOURCES = ["MiniCPM5-1B-MLX"]  # or ["MiniCPM5-1B-MLX-Q4", "MiniCPM5-1B-MLX-bf16"]
 
 block_re = re.compile(
     r"\{%-\s*if\s+enable_thinking\s+is\s+defined\s*%\}.*?"

--- a/docs/deployment/mlx.md
+++ b/docs/deployment/mlx.md
@@ -7,14 +7,14 @@
 ```bash
 pip install "mlx-lm>=0.31"
 
-# Run a pre-converted MLX repo directly
-mlx_lm.generate --model openbmb/MiniCPM5-1B-MLX-4bit \
+# Run the official pre-converted MLX repo directly
+# (config.json declares "quantization": {"bits": 4, "mode": "affine"})
+mlx_lm.generate --model openbmb/MiniCPM5-1B-MLX \
     --prompt "<|im_start|>user
 1+1=?<|im_end|>
 <|im_start|>assistant
 " \
-    --max-tokens 200 --temp 0.7 --top-p 0.95 \
-    --extra-eos-token "<|im_end|>"
+    --max-tokens 200 --temp 0.7 --top-p 0.95
 ```
 
 ## Building MLX weights from your own checkpoint (advanced)
@@ -43,8 +43,7 @@ mlx_lm.generate --model ./minicpm5-mlx-q4 \
 鸡兔同笼，头共10个，脚共28只，问鸡和兔各几只？<|im_end|>
 <|im_start|>assistant
 " \
-    --max-tokens 200 --temp 0.7 --top-p 0.95 \
-    --extra-eos-token "<|im_end|>"
+    --max-tokens 200 --temp 0.7 --top-p 0.95
 ```
 
 ```text
@@ -77,7 +76,7 @@ for resp in stream_generate(
 print()
 ```
 
-> 💡 `--extra-eos-token "<|im_end|>"` (CLI) or adding `<|im_end|>` to the wrapper's stop list (Python) is required: the released metadata only registers `</s>` (id 1) and the secondary EOS id 130073 as model EOS, but the chat template ends turns with the `<|im_end|>` *string*. Without an extra EOS the model will keep generating into the next role's prompt.
+> ℹ️ `<|im_end|>` is **token id 130073** in this tokenizer, and `generation_config.json` already lists it in `eos_token_id: [1, 130073]`. mlx-lm reads that list and adds both ids to the stop set, so no `--extra-eos-token` flag is needed — the model stops at end-of-turn on its own.
 
 ## Recommended sampling
 
@@ -92,7 +91,7 @@ Both modes are activated by sampling parameters only — the released chat templ
 
 ### Model never stops generating
 
-Add `--extra-eos-token "<|im_end|>"` (CLI) or include `<|im_end|>` in `stop` (Python). See note above.
+Confirm you're on `mlx-lm >= 0.31`. Older versions ignored multi-id `eos_token_id` lists in `generation_config.json` and would only stop at `</s>` (id 1) — on a chat-template turn the model never emits `</s>` so it ran past the turn boundary. 0.31+ honours the full list (`[1, 130073]`) and stops at `<|im_end|>` automatically. As a last-resort override you can still pass `--extra-eos-token "<|im_end|>"`.
 
 ## See also
 

--- a/docs/deployment/sglang.md
+++ b/docs/deployment/sglang.md
@@ -9,6 +9,14 @@ pip install "sglang[srt]>=0.5.12"          # latest, requires CUDA 13.x driver
 # pip install "sglang==0.5.6.post3"        # fallback for CUDA 12.x drivers
 ```
 
+> ⚠️ **Tool calling needs a newer build than any current pip release.** The MiniCPM5 XML parser (`--tool-call-parser minicpm5`) landed in [sgl-project/sglang#25600](https://github.com/sgl-project/sglang/pull/25600), merged into `main` on 2026-05-22. The latest release `v0.5.12.post1` was branched earlier and does **not** ship the parser yet. Until `v0.5.13` is tagged, install from source if you need tool calling:
+>
+> ```bash
+> pip install "git+https://github.com/sgl-project/sglang.git@main#subdirectory=python"
+> ```
+>
+> Plain chat completions (no `tools=`) work fine on the pip release — MiniCPM5-1B is a stock `LlamaForCausalLM` so it loads on every SGLang version that supports Llama.
+
 Recommended runtime env vars:
 
 ```bash

--- a/docs/deployment/vllm.md
+++ b/docs/deployment/vllm.md
@@ -76,3 +76,43 @@ out = llm.chat(
 )
 print(out[0].outputs[0].text)
 ```
+
+## Tool calling (plugin)
+
+MiniCPM5-1B emits **XML-style** tool calls. The vLLM-side parser ([vllm-project/vllm#43175](https://github.com/vllm-project/vllm/pull/43175)) was merged to `main` on 2026-05-27 but is **not in any pip release yet** — `v0.22.0` (2026-05-29) was cut before that merge and the file is absent from the v0.22.0 tree.
+
+As a bridge, this repo ships the parser at [`tool_parsers/minicpm5xml_tool_parser.py`](../../tool_parsers/minicpm5xml_tool_parser.py) (the same file as the upstream PR). Load it via vLLM's `--tool-parser-plugin`:
+
+```bash
+vllm serve openbmb/MiniCPM5-1B \
+    --served-model-name MiniCPM5-1B \
+    --dtype bfloat16 --max-model-len 131072 --port 8000 \
+    --enable-auto-tool-choice \
+    --tool-parser-plugin /path/to/MiniCPM/tool_parsers/minicpm5xml_tool_parser.py \
+    --tool-call-parser minicpm5
+```
+
+```bash
+curl http://localhost:8000/v1/chat/completions \
+    -H "Content-Type: application/json" \
+    -d '{
+        "model": "MiniCPM5-1B",
+        "messages": [{"role": "user", "content": "What is the weather in Beijing?"}],
+        "tools": [{
+            "type": "function",
+            "function": {
+                "name": "get_weather",
+                "description": "Get current weather for a city",
+                "parameters": {
+                    "type": "object",
+                    "properties": {"city": {"type": "string"}},
+                    "required": ["city"]
+                }
+            }
+        }],
+        "tool_choice": "auto",
+        "temperature": 0.7, "max_tokens": 256
+    }'
+```
+
+Once vLLM `v0.23` (or later) is released with the parser baked in, drop `--tool-parser-plugin` and use only `--tool-call-parser minicpm5`.

--- a/skills/minicpm5-deploy-arclight/SKILL.md
+++ b/skills/minicpm5-deploy-arclight/SKILL.md
@@ -33,13 +33,16 @@ Use `ARCLIGHT_BACKEND=AUTO` by default. Set it explicitly only when needed:
 
 ### 2. Prepare a GGUF model
 
-ArcLight uses GGUF checkpoints from `llama.cpp`. Use a supported model family:
+ArcLight uses GGUF checkpoints from `llama.cpp`. The `nnml` backend only loads `f32 / f16 / q4_0 / q8_0 / q6_K / q8_K` tensor types — **`Q4_K_M` is not supported**.
 
-- MiniCPM5-1B
-- Qwen3
-- Llama2
+Supported model families: MiniCPM5-1B, Qwen3, Llama2.
 
-For first validation, prefer a small quantized model such as `MiniCPM5-1B-Q4_0.gguf`.
+For first validation use the released `Q8_0` (`openbmb/MiniCPM5-1B-GGUF`), or quantize an unreleased `Q4_0` yourself from the F16:
+
+```bash
+huggingface-cli download openbmb/MiniCPM5-1B-GGUF MiniCPM5-1B-F16.gguf --local-dir .
+llama-quantize ./MiniCPM5-1B-F16.gguf ./MiniCPM5-1B-Q4_0.gguf Q4_0
+```
 
 ### 3A. One-shot generation
 

--- a/skills/minicpm5-deploy-lmstudio/SKILL.md
+++ b/skills/minicpm5-deploy-lmstudio/SKILL.md
@@ -46,15 +46,19 @@ LMS="/Applications/LM Studio.app/Contents/Resources/app/.webpack/lms"
 
 ### 2B. MLX runtime path (Apple Silicon, recommended on Mac)
 
-The MLX runtime needs an MLX-format checkpoint. Either pull a pre-converted one from `openbmb/MiniCPM5-1B-MLX-{bf16,4bit}` (when published) or convert locally — see `minicpm5-deploy-mlx` for the conversion step. Then:
+The MLX runtime needs an MLX-format checkpoint. The only published MLX repo is [`openbmb/MiniCPM5-1B-MLX`](https://huggingface.co/openbmb/MiniCPM5-1B-MLX) (4-bit affine); there is no separate `-bf16` / `-4bit` variant. Either drop that one in as-is, or convert locally from `openbmb/MiniCPM5-1B` (see `minicpm5-deploy-mlx`). Then:
 
 ```bash
-# Drop the converted MLX directory into LM Studio's model registry
+# Option A — use the official pre-quantized repo
+huggingface-cli download openbmb/MiniCPM5-1B-MLX \
+    --local-dir ~/.lmstudio/models/openbmb/MiniCPM5-1B-MLX
+
+# Option B — drop a locally converted directory in
 mkdir -p ~/.lmstudio/models/openbmb/MiniCPM5-1B-MLX-${QUANT}
 cp -r ./minicpm5-mlx-${QUANT}/* ~/.lmstudio/models/openbmb/MiniCPM5-1B-MLX-${QUANT}/
 
 "$LMS" server start
-"$LMS" load minicpm5-1b-mlx-${QUANT} --gpu max -y
+"$LMS" load minicpm5-1b-mlx${QUANT:+-${QUANT}} --gpu max -y
 ```
 
 ### 3. Validate

--- a/skills/minicpm5-deploy-mlx/SKILL.md
+++ b/skills/minicpm5-deploy-mlx/SKILL.md
@@ -11,7 +11,7 @@ Apple's on-device tensor framework. Highest throughput on M-series. Stays inside
 
 | Var | Example | Default |
 | --- | --- | --- |
-| `MLX_REPO` | `openbmb/MiniCPM5-1B-MLX-4bit` (pre-converted) | required |
+| `MLX_REPO` | `openbmb/MiniCPM5-1B-MLX` (pre-converted 4-bit affine) | required |
 | OR `HF_REPO` + `QUANT` | `openbmb/MiniCPM5-1B`, `4bit` or `bf16` | for local conversion |
 | `MAX_TOKENS` | `200` | `200` |
 
@@ -31,8 +31,7 @@ mlx_lm.generate --model "${MLX_REPO}" \
 1+1=?<|im_end|>
 <|im_start|>assistant
 " \
-    --max-tokens ${MAX_TOKENS} --temp 0.7 --top-p 0.95 \
-    --extra-eos-token "<|im_end|>"
+    --max-tokens ${MAX_TOKENS} --temp 0.7 --top-p 0.95
 ```
 
 ### 2B. Convert from a HF checkpoint locally (advanced)
@@ -72,7 +71,7 @@ curl http://127.0.0.1:8000/v1/chat/completions \
 ## Common pitfalls
 
 - **Slow first generate**: MLX JIT-compiles kernels on first call (~5-10 s); subsequent calls hit the warm cache.
-- **Model never stops generating**: pass `--extra-eos-token "<|im_end|>"` (CLI) or add `<|im_end|>` to the Python wrapper's stop list — `</s>` alone doesn't terminate ChatML turns.
+- **Model runs past `<|im_end|>`**: only happens on `mlx-lm < 0.31` (older versions ignore multi-id `eos_token_id` lists). Upgrade, or pass `--extra-eos-token "<|im_end|>"` as a manual override — `<|im_end|>` is token id 130073 and is already listed in `generation_config.json` on 0.31+.
 
 ## When NOT to use
 

--- a/skills/minicpm5-deploy-sglang/SKILL.md
+++ b/skills/minicpm5-deploy-sglang/SKILL.md
@@ -27,6 +27,12 @@ pip install "sglang[srt]>=0.5.12"          # latest, requires CUDA 13.x driver
 # pip install "sglang==0.5.6.post3"        # fallback for CUDA 12.x driver hosts
 ```
 
+**For tool calling, install from `main`** — the `minicpm5` parser ([PR #25600](https://github.com/sgl-project/sglang/pull/25600), merged 2026-05-22) is not in any pip release yet (`v0.5.12.post1` was branched earlier). Plain chat works on the pip release; only `--tool-call-parser minicpm5` needs `main`:
+
+```bash
+pip install "git+https://github.com/sgl-project/sglang.git@main#subdirectory=python"
+```
+
 ### 2. Recommended runtime env vars
 
 ```bash
@@ -111,7 +117,7 @@ print(outputs)
 
 ## Common pitfalls
 
-- **`GLIBCXX_3.4.31 not found`**: conda Python ships an older `libstdc++`. Force-load system: `LD_PRELOAD=/lib/x86_64-linux-gnu/libstdc++.so.6 python -m sglang.launch_server ...`
+- **`GLIBCXX_3.4.31 not found`** (only if you hit it — not universal): conda Python ships an older `libstdc++` than the SGLang wheel was built against. Force-load the system one: `LD_PRELOAD=/lib/x86_64-linux-gnu/libstdc++.so.6 python -m sglang.launch_server ...`
 
 ## When NOT to use
 

--- a/skills/minicpm5-deploy-vllm/SKILL.md
+++ b/skills/minicpm5-deploy-vllm/SKILL.md
@@ -66,6 +66,21 @@ Expected: `choices[0].message.content` contains `"2"`. If you see `<think>...</t
 - **`(free / total) < MEM_FRAC` hard error**: lower `--gpu-memory-utilization` (e.g. 0.5 on a shared GPU).
 - **OOM at startup with 128 K**: drop `--max-model-len` to 32768 or 8192.
 
+## Tool calling (plugin)
+
+The vLLM-side MiniCPM5 XML parser ([PR #43175](https://github.com/vllm-project/vllm/pull/43175)) merged to `main` on 2026-05-27 but is **not in any pip release yet** (`v0.22.0` was cut before the merge). Use the bridge plugin shipped at `tool_parsers/minicpm5xml_tool_parser.py` in this repo:
+
+```bash
+vllm serve "${MODEL_PATH}" \
+    --served-model-name MiniCPM5-1B \
+    --dtype bfloat16 --max-model-len ${CTX_LEN} --port ${PORT} \
+    --enable-auto-tool-choice \
+    --tool-parser-plugin /path/to/MiniCPM/tool_parsers/minicpm5xml_tool_parser.py \
+    --tool-call-parser minicpm5
+```
+
+Drop `--tool-parser-plugin` once vLLM ships a release containing the parser natively.
+
 ## When NOT to use
 
 - One-shot Python script → `minicpm5-deploy-transformers`


### PR DESCRIPTION
…5-1B cookbooks

Audited every backend doc + skill against actual upstream state on 2026-05-31 and fixed five categories of issues:

1. MLX --extra-eos-token is unnecessary

   The previous docs claimed `<|im_end|>` was only registered as a string, not as a model EOS, and so required `--extra-eos-token "<|im_end|>"`. But token id 130073 *is* the string `<|im_end|>` (same token), and `generation_config.json` already lists `eos_token_id: [1, 130073]`, which mlx-lm 0.31+ honours. Removed the flag from all examples and rewrote the explanation; left a Q&A note that older mlx-lm versions (<0.31) need the override.

2. Replaced references to non-existent HF repos

   - `openbmb/MiniCPM5-1B-MLX-4bit` does not exist; the only published MLX repo is `openbmb/MiniCPM5-1B-MLX` (already 4-bit affine per config.json `quantization.bits=4`). Updated mlx.md, mlx SKILL, lmstudio SKILL 2B.
   - The LM Studio variant-generator script in lmstudio.md referenced `MiniCPM5-1B-MLX-Q4` / `MiniCPM5-1B-MLX-bf16` as if pre-existing; added the prerequisite (`mlx_lm.convert` locally, or use the official MLX repo as a single source) and made `SOURCES` adjustable.

3. ArcLight: Q4_0 GGUF is not released, and Q4_K_M is not loadable

   - `openbmb/MiniCPM5-1B-GGUF` publishes F16/Q8_0/Q4_K_M only, not Q4_0.
   - ArcLight's nnml backend only supports f32/f16/q4_0/q8_0/q6_K/q8_K (see ArcLight `nnml/src/ops/types.cpp`); Q4_K_M will not load.
   - Added a `llama-quantize ... Q4_0` step from the released F16, and called out the supported tensor type set explicitly. Updated arclight.md and arclight SKILL.

4. SGLang + vLLM tool-call parsers merged upstream but not in any release

   - sgl-project/sglang#25600 (`minicpm5` parser) merged to main 2026-05-22, but v0.5.12.post1 (2026-05-26) was cherry-picked from an earlier release branch and does not contain it. Added an install-from-source instruction for tool calling only; plain chat still works on the pip release.
   - vllm-project/vllm#43175 (XML tool parser) merged to main 2026-05-27, but v0.22.0 (2026-05-29) does not contain it. The bridge plugin `tool_parsers/minicpm5xml_tool_parser.py` was already in this repo but undocumented; added a new "Tool calling (plugin)" section to vllm.md and the vLLM SKILL showing how to load it via `--tool-parser-plugin` + `--tool-call-parser minicpm5`.

5. Softened over-strict guidance

   - lmstudio.md: changed "always pass stop=[...]" to "add it if you observe overrun" since `<|im_end|>` is in the GGUF's `eos_token_id` and stops normally.
   - sglang SKILL: tagged the `LD_PRELOAD libstdc++` workaround as conditional (only on conda hosts with an old libstdc++).

Files: docs/deployment/{arclight,lmstudio,mlx,sglang,vllm}.md + skills/minicpm5-deploy-{arclight,lmstudio,mlx,sglang,vllm}/SKILL.md