### PR TITLE
docs: quote pip extras install examples

### DIFF
--- a/README-cn.md
+++ b/README-cn.md
@@ -592,7 +592,7 @@ source sglang_minicpm_sala_env/bin/activate
 
 # 2. 安装 SGLang
 uv pip install --upgrade pip setuptools wheel
-uv pip install -e ./python[all]
+uv pip install -e ./'python[all]'
 
 # 3. 编译安装 CUDA 扩展
 # (确保依赖已克隆到 3rdparty/ 目录)

--- a/README.md
+++ b/README.md
@@ -590,7 +590,7 @@ source sglang_minicpm_sala_env/bin/activate
 
 # 2. Install SGLang
 uv pip install --upgrade pip setuptools wheel
-uv pip install -e ./python[all]
+uv pip install -e ./'python[all]'
 
 # 3. Compile CUDA Extensions
 # (Ensure dependencies are cloned to 3rdparty/)


### PR DESCRIPTION
## Summary
- Quote `pip install` examples that include extras.

## Why
- Shells such as zsh can expand unquoted bracket expressions before `pip` receives them.

## Scope
- Files changed:
- `README-cn.md`
- `README.md`
- This does not change dependencies or runtime behavior.

## Testing
- `git diff --check`

## Maintainer Fit
- Small install-command correctness fix.
- Duplicate PR search terms checked: `quote pip extras`, `quote optional dependency`, `zsh pip install extras`, `pip extras install examples`