### PR TITLE
docs(finetune): use template: minicpm5 for LLaMA-Factory

### DIFF
--- a/docs/finetune/llamafactory.md
+++ b/docs/finetune/llamafactory.md
@@ -4,8 +4,12 @@
 
 ## Install
 
+`template: minicpm5` was added in [LLaMA-Factory #10801](https://github.com/hiyouga/LLaMA-Factory/pull/10801), which landed after the latest PyPI release (v0.9.5). Until v0.9.6 ships, install from source:
+
 ```bash
-pip install "llamafactory==0.9.3"        # or just `pip install llamafactory` for latest
+git clone --depth 1 https://github.com/hiyouga/LLaMA-Factory.git
+cd LLaMA-Factory
+pip install -e .
 ```
 
 ## 1. Dataset prep
@@ -64,7 +68,7 @@ lora_target: all          # all linear layers; or "q_proj,k_proj,v_proj,o_proj,g
 ### dataset
 dataset: my_chat_data
 dataset_dir: /path/to/finetune_data
-template: empty           # MiniCPM5 chat template auto-loads from the model's tokenizer_config.json
+template: minicpm5        # MiniCPM5 ChatML template + XML tool calling
 cutoff_len: 4096
 max_samples: 100000
 overwrite_cache: true
@@ -88,7 +92,11 @@ bf16: true
 ddp_timeout: 180000000
 ```
 
-> 💡 `template: empty` tells LLaMA-Factory to **delegate to the tokenizer's built-in `chat_template.jinja`**, which is the MiniCPM5 ChatML-style template (with think / no-think / tools support). Do **not** set `template: llama3` or other built-ins — they will produce a broken token layout.
+> 💡 **Use `template: minicpm5`, not `template: empty`.**
+>
+> LLaMA-Factory does not delegate to the tokenizer's `chat_template.jinja`. `empty` is a real, empty template — bare `{{content}}` slots, no role markers, no EOS replacement, and tools falling back to ReAct `Action:` / `Action Input:` — so training under it silently produces a token layout the model has never seen.
+>
+> `template: minicpm5` reproduces the model's own template byte-for-byte, including think / no-think and XML tool calling. Do **not** set `template: llama3` or other built-ins either.
 
 ## 3. Train
 
@@ -107,7 +115,9 @@ Sample run (200 samples, 1 epoch, single GPU, bs=4, grad_acc=2, lr=2e-4):
 {'train_runtime': 11.45, 'train_samples_per_second': 17.5, 'train_loss': 3.85}
 ```
 
-Loss decreases monotonically from 4.19 → 3.62 over the 25 optimizer steps — the framework + chat template + tokenizer combo all work end-to-end.
+Loss decreases monotonically from 4.19 → 3.62 over the 25 optimizer steps.
+
+> ⚠️ A smoothly decreasing loss does **not** confirm the chat template is correct — a mismatched template trains just as cleanly. Verify the template itself with the sanity check in [§4](#4-inference-with-the-lora-adapter).
 
 ## 4. Inference with the LoRA adapter
 
@@ -122,7 +132,7 @@ llamafactory-cli export merge.yaml
 ```yaml
 model_name_or_path: openbmb/MiniCPM5-1B
 adapter_name_or_path: ./runs/minicpm5_lora
-template: empty
+template: minicpm5
 finetuning_type: lora
 export_dir: ./minicpm5-merged
 export_size: 4
@@ -142,13 +152,17 @@ deepspeed: examples/deepspeed/ds_z2_config.json   # optional, for multi-GPU
 
 ## Q&A
 
-### `template not found` / wrong tokens
+### `Template minicpm5 does not exist`
 
-You probably set `template: llama3` or similar. Use `template: empty` to delegate to the model's own `chat_template.jinja`.
+Your LLaMA-Factory predates [#10801](https://github.com/hiyouga/LLaMA-Factory/pull/10801). It is not in v0.9.5 or earlier — install from source, see [Install](#install).
 
-### `transformers >= 4.55 required` (when also using vLLM in the same env)
+### Garbled output, or tool calls missing the function name
 
-LLaMA-Factory 0.9.3 wants `transformers==4.52`, vLLM 0.21 wants `>=5.6`. Use two virtual environments — one for fine-tuning, one for serving. The merged model is portable across them.
+You trained with `template: empty`, `template: llama3`, or another mismatched built-in. `empty` is not a delegation to the model's `chat_template.jinja`: it trains on a layout the model has never seen, and with tools it teaches ReAct `Action:` / `Action Input:` instead of MiniCPM5's XML. Switch to `template: minicpm5` and retrain.
+
+### `transformers` version conflicts (when also using vLLM in the same env)
+
+From source, LLaMA-Factory requires `transformers>=4.55.0,<=5.8.0` (excluding 4.57.0 and 5.6.0), which can clash with your serving stack. Use two virtual environments — one for fine-tuning, one for serving. The merged model is portable across them.
 
 ### Multi-GPU
 

--- a/skills/minicpm5-finetune-llamafactory/SKILL.md
+++ b/skills/minicpm5-finetune-llamafactory/SKILL.md
@@ -23,10 +23,12 @@ YAML-driven SFT / DPO with WebUI. Most-documented community framework.
 
 ```bash
 python -m venv .venv-lf && source .venv-lf/bin/activate
-pip install "llamafactory==0.9.3"
+# `template: minicpm5` landed after v0.9.5 (the latest PyPI release) — install from source.
+git clone --depth 1 https://github.com/hiyouga/LLaMA-Factory.git
+pip install -e LLaMA-Factory
 ```
 
-> ⚠️ LLaMA-Factory pins `transformers==4.52`. Do NOT install it into a vLLM env (vLLM 0.21 wants `transformers>=5.6`). Always use a separate venv.
+> ⚠️ LLaMA-Factory requires `transformers>=4.55.0,<=5.8.0` (excluding 4.57.0 and 5.6.0), which can clash with a serving stack such as vLLM. Always install it into its own venv.
 
 ### 2. Register the dataset (sharegpt / messages format)
 
@@ -72,7 +74,7 @@ lora_target: all                      # all linear layers
 ### dataset
 dataset: ${DATASET_NAME}
 dataset_dir: ${DATA_DIR}
-template: empty                       # 🔑 MANDATORY for MiniCPM5 — delegates to model's own jinja
+template: minicpm5                    # 🔑 MANDATORY for MiniCPM5 — ChatML + XML tool calling
 cutoff_len: 4096
 max_samples: 100000
 overwrite_cache: true
@@ -96,7 +98,9 @@ bf16: true
 ddp_timeout: 180000000
 ```
 
-> 🔑 **`template: empty` is MANDATORY.** It delegates to the model's own `chat_template.jinja` (which is the MiniCPM5 ChatML template with think / nothink / tools support). Do NOT set `template: llama3` / `qwen` / etc. — those produce a corrupted token layout.
+> 🔑 **`template: minicpm5` is MANDATORY.** It reproduces the model's own `chat_template.jinja` byte-for-byte — ChatML with think / nothink, plus XML tool calling.
+>
+> Do NOT use `template: empty`. LLaMA-Factory does not delegate to the tokenizer's jinja; `empty` is a genuinely empty template (bare `{{content}}` slots, no role markers, no EOS replacement, ReAct-style tools) that trains on a layout the model has never seen. `llama3` / `qwen` / etc. are equally wrong. Requires LLaMA-Factory from source — see step 1.
 
 ### 4. Train
 
@@ -128,7 +132,7 @@ inputs = tok.apply_chat_template([{"role":"user","content":"1+1=?"}], add_genera
 print(tok.decode(model.generate(inputs, max_new_tokens=32, do_sample=False)[0][inputs.shape[-1]:], skip_special_tokens=True))
 ```
 
-Coherent answer ⇒ ✅. Gibberish ⇒ check `template: empty` in the YAML.
+Coherent answer ⇒ ✅. Gibberish ⇒ check `template: minicpm5` in the YAML. (A clean loss curve does **not** confirm the template is right — a mismatched template trains just as smoothly.)
 
 ## Merge LoRA for serving
 
@@ -136,7 +140,7 @@ Coherent answer ⇒ ✅. Gibberish ⇒ check `template: empty` in the YAML.
 cat > ${OUTPUT_DIR}/merge.yaml <<EOF
 model_name_or_path: ${BASE_MODEL}
 adapter_name_or_path: ${OUTPUT_DIR}
-template: empty
+template: minicpm5
 finetuning_type: lora
 export_dir: ./minicpm5-merged
 export_size: 4

--- a/skills/minicpm5-finetune/SKILL.md
+++ b/skills/minicpm5-finetune/SKILL.md
@@ -50,7 +50,7 @@ Each sub-skill expects `BASE_MODEL`, `DATA`, `OUTPUT_DIR` and outputs an LoRA ad
 
 | Framework | Gotcha (skill handles it for you) |
 | --- | --- |
-| LLaMA-Factory | `template: empty` (delegate to model's own jinja, NOT `template: llama3`) |
+| LLaMA-Factory | `template: minicpm5` (needs LLaMA-Factory from source; NOT `template: empty` / `llama3`) |
 | ms-swift | mandatory `--model_type llama --template chatml` flags |
 | TRL | training-only chat template patch for `assistant_only_loss=True` |
 | unsloth | `transformers==4.57.3` pin if vLLM is in the same env |


### PR DESCRIPTION
## What

The LLaMA-Factory fine-tuning docs recommend `template: empty` and explain it as *"delegating to the tokenizer's built-in `chat_template.jinja`"*. That is not what `empty` does, and following the documented recipe silently trains MiniCPM5 on a token layout it has never seen.

LLaMA-Factory merged a real `minicpm5` template in [[hiyouga/LLaMA-Factory#10801](https://github.com/hiyouga/LLaMA-Factory/pull/10801)](https://github.com/hiyouga/LLaMA-Factory/pull/10801). This PR points the docs at it.

## Why `empty` is wrong

`empty` is a genuine empty template — bare `{{content}}` slots, no role markers, no EOS replacement, and tools falling back to ReAct `Action:` / `Action Input:`. Nothing in that path reads the tokenizer's jinja.

## Changes

- `docs/finetune/llamafactory.md` — `template: minicpm5` in the training and merge YAML; rewrite the `empty` explainer; split the Q&A into the real error string (`Template minicpm5 does not exist`) and the garbled-output case
- `skills/minicpm5-finetune-llamafactory/SKILL.md` — same, plus the install step and the sanity-check note
- `skills/minicpm5-finetune/SKILL.md` — the LLaMA-Factory row in the gotcha table

Three things the switch forces along with it:

- **Install from source.** `minicpm5` landed after v0.9.5 (the latest PyPI release), so the documented `pip install "llamafactory==0.9.3"` cannot resolve it — users hit `Template minicpm5 does not exist.` Once v0.9.6 ships this should go back to a pinned release.
- **Refreshed the `transformers` note.** The docs said LLaMA-Factory pins `transformers==4.52`; from source it requires `>=4.55.0,<=5.8.0` (excluding 4.57.0 and 5.6.0).
- **Removed the claim that a decreasing loss validates the chat template.** It does not — that is exactly how this survived.

