### PR TITLE
docs: update links of Just RL II in README files.

### DIFF
--- a/README-cn.md
+++ b/README-cn.md
@@ -187,7 +187,7 @@ MiniCPM5-2B 的训练过程是 **[UltraData 分级数据管理体系](https://ar
 
 #### RL + OPD 带来了什么？
 
-**RL + OPD** 是 MiniCPM5-2B 后训练中的关键环节。**RL** 阶段，使用了 [JustRL II](https://app.notion.com/p/panhaoxuan/JustRL-II-Scaling-Small-LLMs-to-128K-Reasoning-with-a-Critic-3c77e972297c80adb8b5f4b05d267012#5f3eb56b29f048ebab5f71138f12e36f) 阐述的 critic-based 算法，大幅提升训练稳定性，并在多个领域取得了显著的收益。在下面列出的基准中，RL + OPD 在推理与通用能力上平均提升 **↑ 10.96 分**，Agent 能力平均提升 **↑ 6.96 分**。
+**RL + OPD** 是 MiniCPM5-2B 后训练中的关键环节。**RL** 阶段，使用了 [JustRL II](https://panhaoxuan.notion.site/justrl-ii-small-llms-to-128k-reasoning-with-a-critic-cn) 阐述的 critic-based 算法，大幅提升训练稳定性，并在多个领域取得了显著的收益。在下面列出的基准中，RL + OPD 在推理与通用能力上平均提升 **↑ 10.96 分**，Agent 能力平均提升 **↑ 6.96 分**。
 
 
 **OPD** 阶段对 16 个 RL 训练所得到的专家模型（含 5 个 agentic 专家模型）实现了能力合并。训练方式上，我们在 response 序列的每个位置分别对学生模型和教师模型 logits 计算全词表的反向 KL 散度作为优势估计值，替代原有的 verification-based advantage；训练数据上，我们的 OPD 直接复用各 RL teacher 训练时 prompt 作为蒸馏数据，无需额外构造语料。

--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ During **post-training**, we proceed in three steps: **SFT**, **RL**, and **OPD*
 
 #### What does RL + OPD bring?
 
-**RL + OPD** is a key part of MiniCPM5-2B post-training. During the **RL** stage, we adopted the critic-based algorithm described in [JustRL II](https://app.notion.com/p/panhaoxuan/JustRL-II-Scaling-Small-LLMs-to-128K-Reasoning-with-a-Critic-3c77e972297c80adb8b5f4b05d267012#5f3eb56b29f048ebab5f71138f12e36f), substantially improving training stability and achieving significant gains across multiple domains. On the benchmarks listed below, RL + OPD improves reasoning and general capabilities by an average of **↑10.96 points**, and agentic capabilities by **↑6.96 points**.
+**RL + OPD** is a key part of MiniCPM5-2B post-training. During the **RL** stage, we adopted the critic-based algorithm described in [JustRL II](https://panhaoxuan.notion.site/justrl-ii-scaling-small-llms-to-128k-reasoning-with-a-critic), substantially improving training stability and achieving significant gains across multiple domains. On the benchmarks listed below, RL + OPD improves reasoning and general capabilities by an average of **↑10.96 points**, and agentic capabilities by **↑6.96 points**.
 
 **OPD** merges the capabilities of 16 expert models produced by RL training, including 5 agentic expert models. At each response position, we compute the full-vocabulary reverse KL divergence between student and teacher logits as the advantage estimate, replacing the original verification-based advantage. OPD directly reuses the prompts used to train each RL teacher as distillation data, so no additional corpus construction is required.
 


### PR DESCRIPTION
* Updates the Notion link for JustRL II in the MiniCPM5‑2B post‑training documentation from the old URL to the new public one, ensuring proper access for readers.
* This is a documentation‑only change; no code logic or experimental results are affected.